### PR TITLE
Add commas to dial a number with extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ const args = {
 call(args).catch(console.error)
 ```
 
+Example with phone and extension.
+Use commas to add time between pressing different digits. (ex. dial a number and wait to be connected and menu to start being read. Press a number for an extension. Even wait longer for another menus and press another number for another extension.)
+
+```js
+const args = {
+  number: '9093900003,,,3,,,274', // Use commas to add time between digits.
+  prompt: false
+}
+
+call(args).catch(console.error)
+```
+
 ## Limitations
 
 This module only provides a simple wrapper around the Linking API and is thus limited in the functionality it can provide. If you are looking for additional functionality, such as being able to initiate a phone call without user confirmation, please use other packages like [react-native-immediate-phone-call](https://github.com/wumke/react-native-immediate-phone-call).


### PR DESCRIPTION
Added an usage example of using commas in your number argument to allow use of dialing extensions.

I found in my use case that I needed to wait for the phone to ring twice, pick up and start the menu before dialing the extension number. One comma was enough to do that.
```js
const args = {
  number: '18001234567890,,,2#,,,,,456',
}
```

Another use case I used to figure my own out was dialing in to a meeting through the Zoom app. It uses commas to pad the time between numbers and has 2 different extensions.
![img_1753_png](https://user-images.githubusercontent.com/29722966/45524712-1c6d5880-b78d-11e8-8d35-c1cfa2bad4dd.png)


Was helpful for me. Thought some others might find it useful too.